### PR TITLE
make SPDK installation step optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
         compiler:
           - gcc
           - clang
+        spdk-version:
+          - 
+          - none
+          - '21.01.1'
       fail-fast: false
     env:
       CC: ${{ matrix.compiler }}
@@ -35,7 +39,7 @@ jobs:
       - uses: ./
         with:
           dpdk-version: '21.02'
-          spdk-version: '21.01.1'
+          spdk-version: ${{ matrix.spdk-version }}
           target-arch: haswell
       - name: list installed files
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,13 @@ jobs:
       CC: ${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install python3 python3-pip python3-pyelftools python3-setuptools python3-wheel ninja-build 
+      - name: install meson with pip
+        run: |
+          sudo pip3 install meson
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,6 @@ jobs:
       CC: ${{ matrix.compiler }}
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install python3 python3-pip python3-pyelftools python3-setuptools python3-wheel ninja-build 
-      - name: install meson with pip
-        run: |
-          sudo pip3 install meson
       - uses: actions/cache@v2
         with:
           path: |

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,8 @@ inputs:
     required: true
   spdk-version:
     description: SPDK version
-    required: true
+    required: false
+    default: none
   target-arch:
     description: target architecture
     required: false

--- a/main.sh
+++ b/main.sh
@@ -22,7 +22,7 @@ sudo ninja -C build install
 sudo find /usr/local/lib -name 'librte_*.a' -delete
 sudo ldconfig
 
-if [[ ! -z $SPDKVER && -n $SPDKVER && $SPDKVER != "none" ]]; then
+if ! [[ -z $SPDKVER ]] && [[ -n $SPDKVER ]] && [[ $SPDKVER != "none" ]]; then
   mkdir -p  $CODEROOT/spdk_$SPDKVER
   cd $CODEROOT/spdk_$SPDKVER
   if ! [[ -f scripts/pkgdep.sh ]]; then

--- a/main.sh
+++ b/main.sh
@@ -5,9 +5,6 @@ set -o pipefail
 CODEROOT=$HOME/setup-dpdk
 mkdir -p $CODEROOT/dpdk_$DPDKVER
 
-sudo apt-get install python3-pyelftools python3-setuptools
-sudo scripts/pkgdep.sh
-
 cd $CODEROOT/dpdk_$DPDKVER
 if ! [[ -f meson.build ]]; then
   curl -sfL https://static.dpdk.org/rel/dpdk-$DPDKVER.tar.xz | tar -xJ --strip-components=1
@@ -31,6 +28,8 @@ if [[ ! -z $SPDKVER && -n $SPDKVER && $SPDKVER != "none" ]]; then
   if ! [[ -f scripts/pkgdep.sh ]]; then
     curl -sfL https://github.com/spdk/spdk/archive/v$SPDKVER.tar.gz | tar -xz --strip-components=1
   fi
+
+  sudo scripts/pkgdep.sh
 
   cd $CODEROOT/spdk_$SPDKVER
   if ! [[ -f build/lib/libspdk_env_dpdk.a ]]; then

--- a/main.sh
+++ b/main.sh
@@ -2,6 +2,21 @@
 set -e
 set -o pipefail
 
+# Install all dependencies based on the OS distribution
+if [ -n "$(command -v apt-get)" ]; then
+  sudo apt-get update;
+  sudo apt-get -y install \
+    jq \
+    ninja-build \
+    python3 \
+    python3-pip \
+    python3-pyelftools \
+    python3-setuptools \
+    python3-wheel
+    
+  sudo pip3 install meson
+fi
+
 CODEROOT=$HOME/setup-dpdk
 mkdir -p $CODEROOT/dpdk_$DPDKVER
 


### PR DESCRIPTION
Omit installation of SPDK to support projects that do not use it.
This brings more versatility how this Github Action can be applied.
SPDK installation can be skipped by either:
- not setting SPDK version variable
- setting SPDK version variable to an empty string
- setting SPDK version variable to "none"